### PR TITLE
Fix home page list

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,8 @@
+---
+layout: list
+title: AI News
+pagination:
+  enabled: true
+  collection: news
+  per_page: 50
+---


### PR DESCRIPTION
## Summary
- show news list on the site home page

## Testing
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68840fc98db88322b176d948b7138e20