### PR TITLE
Fix Jekyll config dashes

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,11 +1,11 @@
-title: AI‑in‑UAE News
+title: AI-in-UAE News
 theme: minima        # or any Jekyll theme you like
 collections:
   news:
     output: true     # every file in _news becomes a page
     permalink: /news/:slug/
 plugins:
-  - jekyll‑feed      # RSS/Atom feed
-  - jekyll‑sitemap
-  - jekyll‑paginated‑content # optional for pagination
-  - jekyll‑lunr‑js‑search   # optional for instant search
+  - jekyll-feed      # RSS/Atom feed
+  - jekyll-sitemap
+  - jekyll-paginated-content # optional for pagination
+  - jekyll-lunr-js-search   # optional for instant search

--- a/_layouts/list.html
+++ b/_layouts/list.html
@@ -5,12 +5,12 @@ pagination:
   collection: news
   per_page: 50
 ---
-<h1 class="text-3xl font-bold mb-6">AI‑in‑UAE News</h1>
+<h1 class="text-3xl font-bold mb-6">AI-in-UAE News</h1>
 
 <ul class="space-y-3">
 {% for post in paginator.posts %}
   <li>
-    <span class="text-gray-500">{{ post.date | date: "%Y‑%m‑%d" }}</span>
+    <span class="text-gray-500">{{ post.date | date: "%Y-%m-%d" }}</span>
     — <a href="{{ post.url }}">{{ post.title }}</a>
     {% if post.tags %}<span class="text-xs bg-gray-200 px-2 py-0.5 rounded">
       {{ post.tags | join: ", " }}</span>{% endif %}


### PR DESCRIPTION
## Summary
- normalize hyphen characters in `_config.yml`
- fix the home page list template to use normal hyphens

## Testing
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884113208548322b7d446921c71e40f